### PR TITLE
Eliminate bucket relay of window

### DIFF
--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -376,7 +376,7 @@ mod tests {
         assert_eq!(windows.size(), 3);
         assert_eq!(windows.max_width(), 1);
 
-        let window = windows.get(1).unwrap();
+        let window = windows.iter().nth(1).unwrap();
 
         assert_eq!(window.left_width(), 1);
         assert_eq!(window.right_width(), 1);

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -4,6 +4,7 @@ use self::stream::{Model, ModelParameter, Pattern, StreamModels};
 
 pub mod interporation_weight;
 pub mod stream;
+pub mod window;
 
 #[cfg(feature = "htsvoice")]
 mod parser;

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -171,7 +171,6 @@ impl ModelSet {
 
     /// Get dynamic window
     pub fn get_windows(&self, stream_index: usize) -> &Windows {
-        // TODO: check implementation
         &self.get_last_voice().stream_models[stream_index].windows
     }
 

--- a/src/model/parser/mod.rs
+++ b/src/model/parser/mod.rs
@@ -21,6 +21,7 @@ use self::{
 
 use super::{
     stream::{Model, Pattern, StreamModelMetadata, StreamModels},
+    window::Windows,
     GlobalModelMetadata, Voice,
 };
 
@@ -106,7 +107,7 @@ fn parse_data_section<'a, E: ParseError<&'a [u8]> + ContextError<&'a [u8]>>(
                         Ok(all_consuming(terminated(
                             WindowParser::parse_window_row,
                             ParseTarget::sp,
-                        ))(&input[win.0..win.1 + 1])?
+                        ))(&input[win.0..=win.1])?
                         .1)
                     })
                     .collect::<Result<_, _>>()?;
@@ -115,7 +116,7 @@ fn parse_data_section<'a, E: ParseError<&'a [u8]> + ContextError<&'a [u8]>>(
                 stream_data.clone(),
                 stream_model,
                 gv_model,
-                windows,
+                Windows::new(windows),
             ))
         })
         .collect::<Result<_, _>>()?;

--- a/src/model/stream.rs
+++ b/src/model/stream.rs
@@ -2,12 +2,14 @@ use std::fmt::Display;
 
 use regex::Regex;
 
+use super::window::Windows;
+
 pub struct StreamModels {
     pub metadata: StreamModelMetadata,
 
     pub stream_model: Model,
     pub gv_model: Option<Model>,
-    pub windows: Vec<Vec<f64>>,
+    pub windows: Windows,
 }
 
 impl Display for StreamModels {
@@ -21,9 +23,9 @@ impl Display for StreamModels {
             "  Window Width: {}",
             self.windows.iter().fold(String::new(), |acc, curr| {
                 if acc.is_empty() {
-                    format!("{}", curr.len())
+                    format!("{}", curr.width())
                 } else {
-                    format!("{}, {}", acc, curr.len())
+                    format!("{}, {}", acc, curr.width())
                 }
             })
         )?;
@@ -36,7 +38,7 @@ impl StreamModels {
         metadata: StreamModelMetadata,
         stream_model: Model,
         gv_model: Option<Model>,
-        windows: Vec<Vec<f64>>,
+        windows: Windows,
     ) -> Self {
         StreamModels {
             metadata,

--- a/src/model/window.rs
+++ b/src/model/window.rs
@@ -29,13 +29,14 @@ impl Window {
         Self { coefficients }
     }
 
-    pub fn iter(&self) -> impl '_ + Iterator<Item = (WindowIndex, f64)> {
+    pub fn iter_rev(&self, start: usize) -> impl '_ + Iterator<Item = (WindowIndex, f64)> {
         let width = self.width();
-        self.coefficients
+        self.coefficients[start..]
             .iter()
             .enumerate()
-            .zip(std::iter::repeat(width))
-            .map(|((idx, coef), width)| (WindowIndex::new(idx, width), *coef))
+            .rev()
+            .zip(std::iter::repeat((start, width)))
+            .map(|((idx, coef), (start, width))| (WindowIndex::new(start + idx, width), *coef))
     }
 
     #[inline(always)]
@@ -96,18 +97,18 @@ mod tests {
     #[test]
     fn iterator() {
         let window = Window::new(vec![-1.0, 0.0, 1.0]);
-        let iterated = window.iter().collect::<Vec<_>>();
+        let iterated = window.iter_rev(0).collect::<Vec<_>>();
 
-        assert_eq!(iterated[0].1, -1.0);
+        assert_eq!(iterated[2].1, -1.0);
         assert_eq!(iterated[1].1, 0.0);
-        assert_eq!(iterated[2].1, 1.0);
+        assert_eq!(iterated[0].1, 1.0);
 
-        assert_eq!(iterated[0].0.index(), 0);
+        assert_eq!(iterated[2].0.index(), 0);
         assert_eq!(iterated[1].0.index(), 1);
-        assert_eq!(iterated[2].0.index(), 2);
+        assert_eq!(iterated[0].0.index(), 2);
 
-        assert_eq!(iterated[0].0.position(), -1);
+        assert_eq!(iterated[2].0.position(), -1);
         assert_eq!(iterated[1].0.position(), 0);
-        assert_eq!(iterated[2].0.position(), 1);
+        assert_eq!(iterated[0].0.position(), 1);
     }
 }

--- a/src/model/window.rs
+++ b/src/model/window.rs
@@ -11,8 +11,14 @@ impl Windows {
     pub fn iter(&self) -> impl '_ + Iterator<Item = &Window> {
         self.windows.iter()
     }
+    pub fn get(&self, index: usize) -> Option<&Window> {
+        self.windows.get(index)
+    }
     pub fn size(&self) -> usize {
         self.windows.len()
+    }
+    pub fn max_width(&self) -> usize {
+        self.windows.iter().map(Window::width).max().unwrap_or(0) / 2
     }
 }
 
@@ -26,13 +32,16 @@ impl Window {
         Self { coefficients }
     }
 
-    pub fn iter(&self) -> impl '_ + Iterator<Item = (isize, f64)> {
-        let zero_index = (self.coefficients.len() / 2) as isize;
+    pub fn iter(&self) -> impl '_ + Iterator<Item = (WindowIndex, f64)> {
+        let width = self.width();
         self.coefficients
             .iter()
             .enumerate()
-            .zip(std::iter::repeat(zero_index))
-            .map(|((idx, coef), zero_index)| (idx as isize - zero_index, *coef))
+            .zip(std::iter::repeat(width))
+            .map(|((idx, coef), width)| (WindowIndex::new(idx, width), *coef))
+    }
+    pub fn get(&self, index: usize) -> Option<&f64> {
+        self.coefficients.get(index)
     }
 
     #[inline(always)]
@@ -45,6 +54,66 @@ impl Window {
     }
     #[inline(always)]
     pub fn right_width(&self) -> usize {
-        self.width() - self.left_width()
+        self.width() - self.left_width() - 1
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct WindowIndex {
+    index: usize,
+    width: usize,
+}
+
+impl WindowIndex {
+    pub fn new(index: usize, width: usize) -> Self {
+        Self { index, width }
+    }
+
+    #[inline(always)]
+    pub fn position(&self) -> isize {
+        self.index as isize - (self.width / 2) as isize
+    }
+    #[inline(always)]
+    pub fn index(&self) -> usize {
+        self.index
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Window;
+
+    #[test]
+    fn width_1() {
+        let window = Window::new(vec![0.0]);
+        assert_eq!(window.width(), 1);
+        assert_eq!(window.left_width(), 0);
+        assert_eq!(window.right_width(), 0);
+    }
+
+    #[test]
+    fn width_3() {
+        let window = Window::new(vec![-1.0, 0.0, 1.0]);
+        assert_eq!(window.width(), 3);
+        assert_eq!(window.left_width(), 1);
+        assert_eq!(window.right_width(), 1);
+    }
+
+    #[test]
+    fn iterator() {
+        let window = Window::new(vec![-1.0, 0.0, 1.0]);
+        let iterated = window.iter().collect::<Vec<_>>();
+
+        assert_eq!(iterated[0].1, -1.0);
+        assert_eq!(iterated[1].1, 0.0);
+        assert_eq!(iterated[2].1, 1.0);
+
+        assert_eq!(iterated[0].0.index(), 0);
+        assert_eq!(iterated[1].0.index(), 1);
+        assert_eq!(iterated[2].0.index(), 2);
+
+        assert_eq!(iterated[0].0.position(), -1);
+        assert_eq!(iterated[1].0.position(), 0);
+        assert_eq!(iterated[2].0.position(), 1);
     }
 }

--- a/src/model/window.rs
+++ b/src/model/window.rs
@@ -39,15 +39,15 @@ impl Window {
             .map(|((idx, coef), (start, width))| (WindowIndex::new(start + idx, width), *coef))
     }
 
-    #[inline(always)]
+    #[inline]
     pub fn width(&self) -> usize {
         self.coefficients.len()
     }
-    #[inline(always)]
+    #[inline]
     pub fn left_width(&self) -> usize {
         self.width() / 2
     }
-    #[inline(always)]
+    #[inline]
     pub fn right_width(&self) -> usize {
         self.width() - self.left_width() - 1
     }
@@ -64,11 +64,11 @@ impl WindowIndex {
         Self { index, width }
     }
 
-    #[inline(always)]
+    #[inline]
     pub fn position(&self) -> isize {
         self.index as isize - (self.width / 2) as isize
     }
-    #[inline(always)]
+    #[inline]
     pub fn index(&self) -> usize {
         self.index
     }

--- a/src/model/window.rs
+++ b/src/model/window.rs
@@ -1,0 +1,50 @@
+#[derive(Debug, Clone, PartialEq)]
+pub struct Windows {
+    windows: Vec<Window>,
+}
+
+impl Windows {
+    pub fn new(windows: Vec<Window>) -> Self {
+        Self { windows }
+    }
+
+    pub fn iter(&self) -> impl '_ + Iterator<Item = &Window> {
+        self.windows.iter()
+    }
+    pub fn size(&self) -> usize {
+        self.windows.len()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct Window {
+    coefficients: Vec<f64>,
+}
+
+impl Window {
+    pub fn new(coefficients: Vec<f64>) -> Self {
+        Self { coefficients }
+    }
+
+    pub fn iter(&self) -> impl '_ + Iterator<Item = (isize, f64)> {
+        let zero_index = (self.coefficients.len() / 2) as isize;
+        self.coefficients
+            .iter()
+            .enumerate()
+            .zip(std::iter::repeat(zero_index))
+            .map(|((idx, coef), zero_index)| (idx as isize - zero_index, *coef))
+    }
+
+    #[inline(always)]
+    pub fn width(&self) -> usize {
+        self.coefficients.len()
+    }
+    #[inline(always)]
+    pub fn left_width(&self) -> usize {
+        self.width() / 2
+    }
+    #[inline(always)]
+    pub fn right_width(&self) -> usize {
+        self.width() - self.left_width()
+    }
+}

--- a/src/model/window.rs
+++ b/src/model/window.rs
@@ -11,9 +11,6 @@ impl Windows {
     pub fn iter(&self) -> impl '_ + Iterator<Item = &Window> {
         self.windows.iter()
     }
-    pub fn get(&self, index: usize) -> Option<&Window> {
-        self.windows.get(index)
-    }
     pub fn size(&self) -> usize {
         self.windows.len()
     }
@@ -39,9 +36,6 @@ impl Window {
             .enumerate()
             .zip(std::iter::repeat(width))
             .map(|((idx, coef), width)| (WindowIndex::new(idx, width), *coef))
-    }
-    pub fn get(&self, index: usize) -> Option<&f64> {
-        self.coefficients.get(index)
     }
 
     #[inline(always)]

--- a/src/pstream/mlpg.rs
+++ b/src/pstream/mlpg.rs
@@ -38,7 +38,7 @@ impl MlpgMatrix {
             self.wum.push(0.0);
 
             for (i, window) in windows.iter().enumerate() {
-                for (index, coef) in window.iter() {
+                for (index, coef) in window.iter_rev(0) {
                     if coef == 0.0 {
                         continue;
                     }
@@ -50,7 +50,7 @@ impl MlpgMatrix {
                     let wu = coef * parameters[i][idx as usize].1;
                     self.wum[t] += wu * parameters[i][idx as usize].0;
 
-                    for (inner_index, coef) in window.iter().skip(index.index()) {
+                    for (inner_index, coef) in window.iter_rev(index.index()) {
                         if coef == 0.0 {
                             continue;
                         }

--- a/src/pstream/mlpg.rs
+++ b/src/pstream/mlpg.rs
@@ -1,4 +1,4 @@
-use crate::sstream::StateStreamSet;
+use crate::model::window::Windows;
 
 const W1: f64 = 1.0;
 const W2: f64 = 1.0;
@@ -25,14 +25,7 @@ impl MlpgMatrix {
 
     /// Calculate W^T U^{-1} W and W^T U^{-1} \mu
     /// (preparation for calculation of dynamic feature)
-    pub fn calc_wuw_and_wum(
-        &mut self,
-        sss: &StateStreamSet,
-        stream_index: usize,
-        parameters: Vec<Vec<(f64, f64)>>,
-    ) {
-        let windows = sss.get_windows(stream_index);
-
+    pub fn calc_wuw_and_wum(&mut self, windows: &Windows, parameters: Vec<Vec<(f64, f64)>>) {
         self.win_size = windows.size();
         self.length = parameters[0].len();
         self.width = windows.max_width() * 2 + 1;

--- a/src/pstream/mod.rs
+++ b/src/pstream/mod.rs
@@ -36,8 +36,11 @@ impl ParameterStreamSet {
 
             let mut pars = Vec::with_capacity(sss.get_vector_length(i));
             for vector_index in 0..sss.get_vector_length(i) {
-                let parameters: Vec<Vec<(f64, f64)>> = (0..sss.get_window_size(i))
-                    .map(|window_index| {
+                let parameters: Vec<Vec<(f64, f64)>> = sss
+                    .get_windows(i)
+                    .iter()
+                    .enumerate()
+                    .map(|(window_index, window)| {
                         let m = sss.get_vector_length(i) * window_index + vector_index;
 
                         (0..sss.get_total_state())
@@ -65,10 +68,8 @@ impl ParameterStreamSet {
                             .map(|(frame, (mean, ivar))| {
                                 let (left, right) = msd_boundaries[frame];
 
-                                let is_left_msd_boundary =
-                                    sss.get_window_left_width(i, window_index) < -(left as isize);
-                                let is_right_msd_boundary =
-                                    (right as isize) < sss.get_window_right_width(i, window_index);
+                                let is_left_msd_boundary = left < window.left_width();
+                                let is_right_msd_boundary = right < window.right_width();
 
                                 // If the window includes non-msd frames, set the ivar to 0.0
                                 if (is_left_msd_boundary || is_right_msd_boundary)

--- a/src/pstream/mod.rs
+++ b/src/pstream/mod.rs
@@ -85,7 +85,7 @@ impl ParameterStreamSet {
                     .collect();
 
                 let mut mtx = MlpgMatrix::new();
-                mtx.calc_wuw_and_wum(sss, i, parameters);
+                mtx.calc_wuw_and_wum(sss.get_windows(i), parameters);
 
                 let par = if sss.use_gv(i) {
                     let mtx_before = mtx.clone();

--- a/src/sstream.rs
+++ b/src/sstream.rs
@@ -2,7 +2,10 @@ use std::sync::Arc;
 
 use crate::{
     label::Label,
-    model::{interporation_weight::InterporationWeight, stream::ModelParameter, ModelSet},
+    model::{
+        interporation_weight::InterporationWeight, stream::ModelParameter, window::Windows,
+        ModelSet,
+    },
 };
 
 pub struct StateStreamSet {
@@ -212,31 +215,9 @@ impl StateStreamSet {
     pub fn get_msd(&self, stream_index: usize, state_index: usize) -> f64 {
         self.sstreams[stream_index].params[state_index].msd.unwrap()
     }
-    /// Get dynamic window size
-    pub fn get_window_size(&self, stream_index: usize) -> usize {
-        self.ms.get_window_size(stream_index)
-    }
-    /// Get left width of dynamic window
-    pub fn get_window_left_width(&self, stream_index: usize, window_index: usize) -> isize {
-        self.ms.get_window_left_width(stream_index, window_index)
-    }
-    /// Get right width of dynamic window
-    pub fn get_window_right_width(&self, stream_index: usize, window_index: usize) -> isize {
-        self.ms.get_window_right_width(stream_index, window_index)
-    }
-    /// Get coefficient of dynamic window
-    pub fn get_window_coefficient(
-        &self,
-        stream_index: usize,
-        window_index: usize,
-        coefficient_index: isize,
-    ) -> f64 {
-        self.ms
-            .get_window_coefficient(stream_index, window_index, coefficient_index)
-    }
-    /// Get max width of dynamic window
-    pub fn get_window_max_width(&self, stream_index: usize) -> usize {
-        self.ms.get_window_max_width(stream_index)
+    /// TODO: remove this
+    pub fn get_windows(&self, stream_index: usize) -> &Windows {
+        self.ms.get_windows(stream_index)
     }
     /// Get GV flag
     pub fn use_gv(&self, stream_index: usize) -> bool {


### PR DESCRIPTION
`TODO: remove this`となっている部分は，今後LabelとSStreamSetのリファクタリングをする際に消す予定です．

参考までにベンチマークの結果を．

main
```
test bonsai        ... bench:  17,225,324 ns/iter (+/- 71,784)
test bonsai_letter ... bench:  47,869,986 ns/iter (+/- 102,811)
test is_bonsai     ... bench:  26,584,675 ns/iter (+/- 73,453)
```

4b8b1e3
```
test bonsai        ... bench:  16,898,101 ns/iter (+/- 35,576)
test bonsai_letter ... bench:  47,021,735 ns/iter (+/- 240,455)
test is_bonsai     ... bench:  26,094,654 ns/iter (+/- 92,799)
```