### PR TITLE
refactor: MelLogSpectrumApproximation::fir

### DIFF
--- a/src/vocoder/mlsa.rs
+++ b/src/vocoder/mlsa.rs
@@ -83,6 +83,7 @@ impl<const N: usize> MelLogSpectrumApproximation<N> {
     // Code optimization was done in
     // [#12](https://github.com/jpreprocess/jbonsai/pull/12)
     // [#16](https://github.com/jpreprocess/jbonsai/pull/16)
+    // [#57](https://github.com/jpreprocess/jbonsai/pull/57)
     #[inline(always)]
     fn fir(d: &mut [f64], x: f64, alpha: f64, coefficients: &'_ Coefficients) -> f64 {
         Self::fir_step1(d, x, alpha);


### PR DESCRIPTION
## 概要

- `d` (`d21`) のうち実質的に使っていなかった `d[0]` (`d21[*][0]`) を消して寄せた．
- `fir` を `fir_step1` と `fir_step2` に分割した．
- `fir_step1` の最初の処理をできるだけループ内に寄せるようにした．
- 各 step の細かい処理について
- 行列演算の可能性について

## `d[0]` の消去

元のコードでは，`d[0]` には `fir` の最初に `x` が代入されており，参照は全て `x` に置き換えられるものであった．

## 分割について

`fir` はもともと3つの `for` ループからなっていた（#12 を参照）ところを1つのループに統合されている．このうち3つ目だったループは単に `d` のインデックスをずらすだけの処理であり，2つ目だったループの内積計算はインデックスの読み替えにより完全に分割できた．これにより，パフォーマンスチューニングも2つに分けて行うことができるようになる．
なお，簡単にプロファイルした限り，`fir_step1` と `fir_step2` の占める割合はいい勝負であるようだ（真ん中あたりが `fir_step1`，その右が `fir_step2`）．

![flamegraph](https://github.com/user-attachments/assets/5b3547ec-71b4-4fbb-8fc5-a204b148df2e)

## `fir_step1` の最初の処理

`fir_step1` 全体を見たときに，1箇所を除いては完全に同じ処理を行うようになっている（インデックスのズレを除く）．その1箇所というのが，`d[1] = aa * d[0] + alpha * d[1]` の最後の `d[1]` である．これを`d[2]`（インデックスをずらして d[1]）に読み替えている．初期値やそれ以降の計算結果が全く変わらないのか，この変更の後もテストが通ったため，まあ大丈夫なのだろうと思っている．

## 各 step の仔細

`fir_step1` については，2つの論点がある．
- `std::mem::swap` ではなく入れ替え代入の方が若干だが速かった．意味論に参照の書き換えと Copy 代入との違いがあり，Copy の方がわずかにパフォーマンスで上回ったのだと思われる．
- `get_unchecked` や `get_unchecked_mut` は効果がなかった．コンパイラが静的解析により，`i` の元となる `0..d.len() - 1` から全てのインデックスアクセスが out-of-bound にならないと確信し，チェック用のコードを取り除いてくれていると思われる．

<details>
<summary>fir_step1の比較</summary>

main
```rs
let di = d.get_unchecked(i) + alpha * (d.get_unchecked(i + 1) - prev);
y += di * coefficients.get_unchecked(i);
*d.get_unchecked_mut(i) = std::mem::replace(&mut prev, di);
```
```
test bonsai        ... bench:  26,472,504.10 ns/iter (+/- 1,447,287.09)
test bonsai_letter ... bench:  71,450,441.70 ns/iter (+/- 6,946,882.04)
test is_bonsai     ... bench:  40,235,429.10 ns/iter (+/- 1,960,200.49)
```

---

HEAD
```rs
d[i] += alpha * (d[i + 1] - prev);
(d[i], prev) = (prev, d[i]);
```
```
test bonsai        ... bench:  25,321,016.70 ns/iter (+/- 1,195,496.20)
test bonsai_letter ... bench:  69,367,633.30 ns/iter (+/- 2,013,533.89)
test is_bonsai     ... bench:  38,847,587.50 ns/iter (+/- 1,469,389.15)
```

---

```rs
d[i] += alpha * (d[i + 1] - prev);
std::mem::swap(&mut d[i], &mut prev);
```
```
test bonsai        ... bench:  25,624,887.50 ns/iter (+/- 4,596,076.28)
test bonsai_letter ... bench:  69,990,841.70 ns/iter (+/- 8,407,358.05)
test is_bonsai     ... bench:  38,832,358.30 ns/iter (+/- 809,401.31)
```

---

```rs
*d.get_unchecked_mut(i) += alpha * (d.get_unchecked(i + 1) - prev);
(*d.get_unchecked_mut(i), prev) = (prev, *d.get_unchecked(i));
```
```
test bonsai        ... bench:  25,331,566.70 ns/iter (+/- 143,227.85)
test bonsai_letter ... bench:  69,514,158.30 ns/iter (+/- 1,014,210.43)
test is_bonsai     ... bench:  38,858,120.80 ns/iter (+/- 289,435.84)
```

---

```rs
*d.get_unchecked_mut(i) += alpha * (d.get_unchecked(i + 1) - prev);
std::mem::swap(d.get_unchecked_mut(i), &mut prev);
```
```
test bonsai        ... bench:  25,365,316.70 ns/iter (+/- 1,349,442.47)
test bonsai_letter ... bench:  69,455,362.50 ns/iter (+/- 3,052,368.23)
test is_bonsai     ... bench:  39,090,562.50 ns/iter (+/- 4,232,488.75)
```
</details>

`fir_step2` については，1つ論点がある．
- unsafe を使うと確かに速くなるのだが，その分事前に coefficient の長さを assert しておく必要があり，これによって若干遅くなる．`d21[*]` はすべて長さが同じに作られるという性質を利用して assert を減らすと少々マシになるが，余計に複雑になるため，やめておいた．

<details>
<summary>fir_step2 の比較</summary>

main
```
test bonsai        ... bench:  26,472,504.10 ns/iter (+/- 1,447,287.09)
test bonsai_letter ... bench:  71,450,441.70 ns/iter (+/- 6,946,882.04)
test is_bonsai     ... bench:  40,235,429.10 ns/iter (+/- 1,960,200.49)
```

---

HEAD

```rs
y += d[i] * coefficients[i];
```
```
test bonsai        ... bench:  24,662,704.10 ns/iter (+/- 734,613.66)
test bonsai_letter ... bench:  67,866,712.50 ns/iter (+/- 7,676,029.13)
test is_bonsai     ... bench:  38,092,454.20 ns/iter (+/- 6,362,859.05)
```

---

`fir_step2` 内で `assert_eq!` したのち unsafe

```rs
test bonsai        ... bench:  29,796,479.20 ns/iter (+/- 786,414.48)
test bonsai_letter ... bench:  81,185,433.30 ns/iter (+/- 1,852,643.40)
test is_bonsai     ... bench:  45,547,708.40 ns/iter (+/- 1,050,462.15)
```

`df2` 内で `assert_eq!` したのち unsafe

```rs
test bonsai        ... bench:  24,117,737.40 ns/iter (+/- 1,086,713.31)
test bonsai_letter ... bench:  66,390,233.40 ns/iter (+/- 1,948,898.75)
test is_bonsai     ... bench:  37,037,279.20 ns/iter (+/- 729,849.62)
```

</details>

## 行列演算の可能性

`fir_step1` の最初の処理の単純化により，for ループをいくつか展開して計算式を導出してみる試みが可能になった．これにより，`alpha` にのみ依存する係数行列を用いて `fir_step1` を行列演算として表現することができたようである．

`a` を `alpha`，`da` を `fir_step1` 実行前の `d`，`dr` を `fir_step1` 実行後の `d` とすると，計算は以下のように表現される：
```
dr0 =                                                                             a x
dr1 =                                                         a da1 +     (1 - a^2) x
dr2 =                                     a da2 +     (1 - a^2) da1 - a   (1 - a^2) x
dr3 =                 a da3 +     (1 - a^2) da2 - a   (1 - a^2) da1 + a^2 (1 - a^2) x
dr4 = a da4 + (1 - a^2) da3 - a   (1 - a^2) da2 + a^2 (1 - a^2) da1 - a^3 (1 - a^2) x
...
```
これは，最初に`d[0] = x`とすることで，`dr = M(a) * da` という極めて単純な行列演算として表される．ここで，`M(a)` は `alpha` にのみ依存する行列であり，`alpha` としてありうる値は各合成の中で変化しないため，これを事前に計算することで更なる高速化が可能であると考えられる．

追記：現在のアルゴリズムは思いのほか速いらしく（行列演算が O(`nmcp`^2) であるところこのアルゴリズムは O(`nmcp`) である），行列をキャッシュするようにしてもそこまで高速化しなかった．

`fir_step2` は見ての通り内積である．行列演算ライブラリによる高速化が期待できる．