### PR TITLE
chore: use default rustup profile

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -28,13 +28,9 @@ jobs:
         run: cargo test --verbose --all-features -- --include-ignored
 
       - name: Run Clippy
-        run: |
-          rustup component add clippy --toolchain nightly-x86_64-unknown-linux-gnu
-          cargo clippy --all-targets
+        run: cargo clippy --all-targets
       - name: Run Format Check
-        run: |
-          rustup component add rustfmt --toolchain nightly-x86_64-unknown-linux-gnu
-          cargo fmt --check
+        run: cargo fmt --check
 
   build-stable:
     runs-on: ubuntu-latest

--- a/patches/toolchain-to-stable.patch
+++ b/patches/toolchain-to-stable.patch
@@ -1,6 +1,7 @@
 --- rust-toolchain.toml
 +++ rust-toolchain.toml
-@@ -1,2 +1,2 @@
+@@ -1,3 +1,3 @@
  [toolchain]
 -channel = "nightly"
 +channel = "stable"
+ profile = "default"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,3 @@
 [toolchain]
 channel = "nightly"
+profile = "default"


### PR DESCRIPTION
Automatically include required components by setting default profile in rust-toolchain.toml
