### PR TITLE
ci: add --fuzz=0 to patch command for stricter patching

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -45,7 +45,7 @@ jobs:
           submodules: true
 
       - name: Use stable
-        run: patch --strip=0 <patches/toolchain-to-stable.patch
+        run: patch --fuzz=0 --strip=0 <patches/toolchain-to-stable.patch
 
       - name: Cache Cargo dependencies
         uses: Swatinem/rust-cache@3cf7f8cc28d1b4e7d01e3783be10a97d55d483c8 # v2.7.1


### PR DESCRIPTION
予期せぬビルド動作を防止するため、パッチ適用を厳格化しました。
fuzz factorをゼロに設定することで、toolchain-to-stableパッチ適用時に
正確なコンテキスト一致が必要となります。
